### PR TITLE
Added means to statically obtain context

### DIFF
--- a/GFSTimeClock/app/src/main/java/com/github/gfsclock/gfstimeclock/Startup.java
+++ b/GFSTimeClock/app/src/main/java/com/github/gfsclock/gfstimeclock/Startup.java
@@ -5,6 +5,7 @@ package com.github.gfsclock.gfstimeclock;
  */
 
 import android.app.Application;
+import android.content.Context;
 
 import io.realm.Realm;
 
@@ -12,10 +13,18 @@ import io.realm.Realm;
  * Startup()
  * This function initializes a new Realm instance.
  */
-public class Startup extends Application{
+public class Startup extends Application {
+
+    private static Context context;
+
+    public static Context getContext() {
+        return context;
+    }
+
     @Override
     public void onCreate(){
         super.onCreate();
+        context = getApplicationContext();
         Realm.init(this);
     }
 }


### PR DESCRIPTION
Context can be retrieved through a static call to Startup.getContext();

Fulfills #81.